### PR TITLE
Fix window icon

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -37,7 +37,7 @@ module.exports = function main() {
 		} );
 
 		// Create the browser window.
-		var iconPath = path.join( __dirname, '/lib/icons/app-icon/icon_256x256.png' );
+		var iconPath = path.join( __dirname, '../lib/icons/app-icon/icon_256x256.png' );
 		mainWindow = new BrowserWindow( {
 			x: mainWindowState.x,
 			y: mainWindowState.y,


### PR DESCRIPTION
Fixes #316. `__dirname` called the wrong path (`./desktop/lib/icons/app-icon/icon_256x256.png` instead of ./lib/icons/app-icon/icon_256x256.png`). Tested in Arch (Manjaro), Xfce.